### PR TITLE
Configure static export for Netlify deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "npm run deploy"
   publish = "out"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "deploy": "npm run build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
Configures Next.js for static export by updating build scripts and Netlify configuration, adapting to `next export` deprecation in Next.js 14+.

The `next export` command is deprecated in Next.js 13+ when `output: 'export'` is set in `next.config.js`. `next build` now directly generates the static output in `/out`. This PR updates the `deploy` script to simply run `npm run build` and adjusts `netlify.toml` accordingly, ensuring correct static site generation and deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-deff4b43-469f-4b86-a50b-cc111fc807ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-deff4b43-469f-4b86-a50b-cc111fc807ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

