### PR TITLE
Récupérer la commande digest

### DIFF
--- a/ingest-new-only.sh
+++ b/ingest-new-only.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Script pour n'ingérer que les nouvelles images
+# Utilise les timestamps pour détecter les nouvelles images
+
+CANVAS_DIR="assets/raw/canvas"
+MOCKUPS_DIR="assets/raw/mockups"
+TEMP_DIR="assets/raw/temp_new"
+BACKUP_DIR="assets/raw/backup"
+
+# Créer les dossiers si nécessaire
+mkdir -p "$TEMP_DIR/canvas"
+mkdir -p "$TEMP_DIR/mockups"
+mkdir -p "$BACKUP_DIR/canvas"
+mkdir -p "$BACKUP_DIR/mockups"
+
+# Fichier de timestamp pour tracker la dernière ingestion
+TIMESTAMP_FILE=".last_ingest_timestamp"
+
+# Si le fichier timestamp existe, trouver les nouvelles images
+if [ -f "$TIMESTAMP_FILE" ]; then
+    echo "🔍 Recherche des nouvelles images depuis la dernière ingestion..."
+    
+    # Trouver et copier les nouvelles images canvas
+    find "$CANVAS_DIR" -type f \( -name "*.jpg" -o -name "*.jpeg" -o -name "*.png" \) -newer "$TIMESTAMP_FILE" -exec cp {} "$TEMP_DIR/canvas/" \;
+    
+    # Trouver et copier les nouvelles images mockups
+    find "$MOCKUPS_DIR" -type f \( -name "*.jpg" -o -name "*.jpeg" -o -name "*.png" \) -newer "$TIMESTAMP_FILE" -exec cp {} "$TEMP_DIR/mockups/" \;
+    
+    # Compter les nouvelles images
+    NEW_CANVAS=$(find "$TEMP_DIR/canvas" -type f | wc -l)
+    NEW_MOCKUPS=$(find "$TEMP_DIR/mockups" -type f | wc -l)
+    
+    if [ "$NEW_CANVAS" -eq 0 ] && [ "$NEW_MOCKUPS" -eq 0 ]; then
+        echo "✅ Aucune nouvelle image à traiter"
+        rm -rf "$TEMP_DIR"
+        exit 0
+    fi
+    
+    echo "📸 Nouvelles images trouvées: $NEW_CANVAS canvas, $NEW_MOCKUPS mockups"
+    
+    # Backup des images originales
+    echo "💾 Sauvegarde des images originales..."
+    cp -r "$CANVAS_DIR"/* "$BACKUP_DIR/canvas/" 2>/dev/null || true
+    cp -r "$MOCKUPS_DIR"/* "$BACKUP_DIR/mockups/" 2>/dev/null || true
+    
+    # Remplacer temporairement par seulement les nouvelles images
+    rm -rf "$CANVAS_DIR"/*
+    rm -rf "$MOCKUPS_DIR"/*
+    cp -r "$TEMP_DIR/canvas"/* "$CANVAS_DIR/" 2>/dev/null || true
+    cp -r "$TEMP_DIR/mockups"/* "$MOCKUPS_DIR/" 2>/dev/null || true
+    
+    # Exécuter l'ingestion
+    echo "🚀 Ingestion des nouvelles images..."
+    npm run ingest
+    
+    # Restaurer toutes les images
+    echo "♻️ Restauration de toutes les images..."
+    cp -r "$BACKUP_DIR/canvas"/* "$CANVAS_DIR/" 2>/dev/null || true
+    cp -r "$BACKUP_DIR/mockups"/* "$MOCKUPS_DIR/" 2>/dev/null || true
+    
+else
+    echo "🆕 Première ingestion - traitement de toutes les images..."
+    npm run ingest
+fi
+
+# Mettre à jour le timestamp
+touch "$TIMESTAMP_FILE"
+
+# Nettoyer
+rm -rf "$TEMP_DIR"
+
+echo "✨ Ingestion terminée!"

--- a/ingest-smart.sh
+++ b/ingest-smart.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Script intelligent pour n'ingérer que les images modifiées
+# Utilise les checksums MD5 pour détecter les changements
+
+CANVAS_DIR="assets/raw/canvas"
+MOCKUPS_DIR="assets/raw/mockups"
+CHECKSUM_FILE=".image_checksums"
+TEMP_DIR="assets/raw/temp_process"
+
+# Créer les dossiers si nécessaire
+mkdir -p "$TEMP_DIR/canvas"
+mkdir -p "$TEMP_DIR/mockups"
+mkdir -p "$CANVAS_DIR"
+mkdir -p "$MOCKUPS_DIR"
+
+# Fonction pour calculer le checksum d'un fichier
+get_checksum() {
+    md5sum "$1" 2>/dev/null | cut -d' ' -f1
+}
+
+# Charger les checksums précédents
+declare -A OLD_CHECKSUMS
+if [ -f "$CHECKSUM_FILE" ]; then
+    while IFS='=' read -r file checksum; do
+        OLD_CHECKSUMS["$file"]="$checksum"
+    done < "$CHECKSUM_FILE"
+fi
+
+# Calculer les nouveaux checksums et identifier les changements
+declare -A NEW_CHECKSUMS
+NEW_COUNT=0
+MODIFIED_COUNT=0
+
+echo "🔍 Analyse des images..."
+
+# Analyser les images canvas
+for img in "$CANVAS_DIR"/*.{jpg,jpeg,png} 2>/dev/null; do
+    [ -f "$img" ] || continue
+    
+    checksum=$(get_checksum "$img")
+    filename=$(basename "$img")
+    NEW_CHECKSUMS["canvas/$filename"]="$checksum"
+    
+    if [ -z "${OLD_CHECKSUMS[canvas/$filename]}" ]; then
+        echo "  ✨ Nouvelle: $filename"
+        cp "$img" "$TEMP_DIR/canvas/"
+        ((NEW_COUNT++))
+    elif [ "${OLD_CHECKSUMS[canvas/$filename]}" != "$checksum" ]; then
+        echo "  📝 Modifiée: $filename"
+        cp "$img" "$TEMP_DIR/canvas/"
+        ((MODIFIED_COUNT++))
+    fi
+done
+
+# Analyser les mockups
+for img in "$MOCKUPS_DIR"/*.{jpg,jpeg,png} 2>/dev/null; do
+    [ -f "$img" ] || continue
+    
+    checksum=$(get_checksum "$img")
+    filename=$(basename "$img")
+    NEW_CHECKSUMS["mockups/$filename"]="$checksum"
+    
+    if [ -z "${OLD_CHECKSUMS[mockups/$filename]}" ]; then
+        echo "  ✨ Nouvelle: $filename"
+        cp "$img" "$TEMP_DIR/mockups/"
+        ((NEW_COUNT++))
+    elif [ "${OLD_CHECKSUMS[mockups/$filename]}" != "$checksum" ]; then
+        echo "  📝 Modifiée: $filename"
+        cp "$img" "$TEMP_DIR/mockups/"
+        ((MODIFIED_COUNT++))
+    fi
+done
+
+TOTAL_CHANGES=$((NEW_COUNT + MODIFIED_COUNT))
+
+if [ "$TOTAL_CHANGES" -eq 0 ]; then
+    echo "✅ Aucun changement détecté - les images optimisées sont à jour"
+    rm -rf "$TEMP_DIR"
+    exit 0
+fi
+
+echo ""
+echo "📊 Résumé: $NEW_COUNT nouvelles, $MODIFIED_COUNT modifiées"
+echo ""
+
+# Sauvegarder les images actuelles
+BACKUP_DIR="assets/raw/.backup_$(date +%s)"
+mkdir -p "$BACKUP_DIR"
+cp -r "$CANVAS_DIR" "$BACKUP_DIR/" 2>/dev/null || true
+cp -r "$MOCKUPS_DIR" "$BACKUP_DIR/" 2>/dev/null || true
+
+# Remplacer temporairement par seulement les images à traiter
+mv "$CANVAS_DIR" "$CANVAS_DIR.old"
+mv "$MOCKUPS_DIR" "$MOCKUPS_DIR.old"
+mv "$TEMP_DIR/canvas" "$CANVAS_DIR"
+mv "$TEMP_DIR/mockups" "$MOCKUPS_DIR"
+
+# Exécuter l'ingestion
+echo "🚀 Ingestion des images modifiées..."
+npm run ingest
+
+# Restaurer toutes les images
+rm -rf "$CANVAS_DIR"
+rm -rf "$MOCKUPS_DIR"
+mv "$CANVAS_DIR.old" "$CANVAS_DIR"
+mv "$MOCKUPS_DIR.old" "$MOCKUPS_DIR"
+
+# Sauvegarder les nouveaux checksums
+> "$CHECKSUM_FILE"
+for key in "${!NEW_CHECKSUMS[@]}"; do
+    echo "$key=${NEW_CHECKSUMS[$key]}" >> "$CHECKSUM_FILE"
+done
+
+# Nettoyer
+rm -rf "$TEMP_DIR"
+rm -rf "$BACKUP_DIR"
+
+echo "✨ Ingestion terminée! ($TOTAL_CHANGES images traitées)"

--- a/scripts/ingest-images.mjs
+++ b/scripts/ingest-images.mjs
@@ -30,10 +30,10 @@ const WATERMARK_TEXT = 'AURA ON CANVAS';           // change if needed
 // Canvas files (your screenshot shows "BLUE-1-1.jpeg" etc):
 // Accepts "BLUE-1-1.jpg" or "BLUE-1.jpg" or "BLUE1-1.jpg"
 // Now also accepts IDENTITY series
-const canvasRe = /^(BLUE|GREEN|RED|IDENTITY)-?(\d+)-(?:1|C\d+)?\.(png|jpe?g)$/i;
+const canvasRe = /^(BLUE|GREEN|RED|IDENTITY|LION)-?(\d+)(?:-(\d+|C\d+))?\.(png|jpe?g)$/i;
 
 // Mockups "BLUE-1-M3.png" etc.
-const mockupRe = /^(BLUE|GREEN|RED|IDENTITY)-?(\d+)-M(\d+)\.(png|jpe?g)$/i;
+const mockupRe = /^(BLUE|GREEN|RED|IDENTITY|LION)-?(\d+)-M(\d+)\.(png|jpe?g)$/i;
 
 // Read mapping key -> slug/title/etsyId
 let map = [];
@@ -48,7 +48,8 @@ const seriesSlugPrefix = {
 	BLUE:'blue-androgyne-no', 
 	GREEN:'green-vision-no', 
 	RED:'red-vision-no',
-	IDENTITY:'identity-no' 
+	IDENTITY:'identity-no',
+	LION:'lion-no' 
 };
 
 function buildPublicPath(slug, filename) {

--- a/scripts/ingest-images.mjs
+++ b/scripts/ingest-images.mjs
@@ -29,10 +29,11 @@ const WATERMARK_TEXT = 'AURA ON CANVAS';           // change if needed
 // ---- Filename patterns ----
 // Canvas files (your screenshot shows "BLUE-1-1.jpeg" etc):
 // Accepts "BLUE-1-1.jpg" or "BLUE-1.jpg" or "BLUE1-1.jpg"
-const canvasRe = /^(BLUE|GREEN|RED)-?(\d+)-(?:1|C\d+)?\.(png|jpe?g)$/i;
+// Now also accepts IDENTITY series
+const canvasRe = /^(BLUE|GREEN|RED|IDENTITY)-?(\d+)-(?:1|C\d+)?\.(png|jpe?g)$/i;
 
 // Mockups "BLUE-1-M3.png" etc.
-const mockupRe = /^(BLUE|GREEN|RED)-?(\d+)-M(\d+)\.(png|jpe?g)$/i;
+const mockupRe = /^(BLUE|GREEN|RED|IDENTITY)-?(\d+)-M(\d+)\.(png|jpe?g)$/i;
 
 // Read mapping key -> slug/title/etsyId
 let map = [];
@@ -43,7 +44,12 @@ try {
 }
 
 // Fallback for slug if mapping is missing
-const seriesSlugPrefix = { BLUE:'blue-androgyne-no', GREEN:'green-vision-no', RED:'red-vision-no' };
+const seriesSlugPrefix = { 
+	BLUE:'blue-androgyne-no', 
+	GREEN:'green-vision-no', 
+	RED:'red-vision-no',
+	IDENTITY:'identity-no' 
+};
 
 function buildPublicPath(slug, filename) {
 	return `/images/works/${slug}/${filename}`;


### PR DESCRIPTION
Add `ingest-smart.sh` and `ingest-new-only.sh` scripts to optimize image ingestion by processing only new or modified images.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0685dea-f359-497a-bc65-890cc598bc22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0685dea-f359-497a-bc65-890cc598bc22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

